### PR TITLE
Update internal link generation to schedule post

### DIFF
--- a/index.md
+++ b/index.md
@@ -9,7 +9,7 @@ Competitive programming is recognized and supported by several multinational sof
 
 # Upcoming Events
 
-You can find list of events held this quarter [<span style = "color:blue">here</span>]({% link _posts/2020-05-19-Spring-20-Schedule.md%}). The document would be updated accordingly each quarter with new events. Stay tuned to this page!
+You can find list of events held this quarter [<span style = "color:blue">here</span>]({{ site.baseurl }}{% link _posts/2020-05-19-Spring-20-Schedule.md %}). The document would be updated accordingly each quarter with new events. Stay tuned to this page!
 
 ----
 ----


### PR DESCRIPTION
The original link on the home page was broken, probably due to the version of Jekyll being used, since Jekyll versions earlier than 4.0 do not prepend `link` items with `site.baseurl`. GitHub Pages uses Jekyll v3.8.7 internally; see https://pages.github.com/versions/.

Note that once you switch to a subdomain, this change should no longer be necessary.

See https://jekyllrb.com/docs/liquid/tags/#links for more information about how Liquid links are handled.

If this were in an output tag instead of a logical tag, you could use the `relative_url` filter to generate the correct permalink; see https://jekyllrb.com/docs/liquid/filters/ for more information
about this filter and others.